### PR TITLE
Make `resize` action support `Element`, not just `HTMLElement`

### DIFF
--- a/.changeset/gentle-gorillas-battle.md
+++ b/.changeset/gentle-gorillas-battle.md
@@ -1,0 +1,5 @@
+---
+'@svelte-put/resize': minor
+---
+
+relax node type to `Element`

--- a/packages/resize/src/public.d.ts
+++ b/packages/resize/src/public.d.ts
@@ -62,7 +62,7 @@ export interface ResizeDetail {
 }
 
 /**  */
-export type ResizeAction = Action<HTMLElement, ResizeParameter, ResizeAttributes>;
+export type ResizeAction = Action<Element, ResizeParameter, ResizeAttributes>;
 
 /**  */
 export type ResizeActionReturn = ActionReturn<ResizeParameter, ResizeAttributes>;

--- a/packages/resize/src/resize.js
+++ b/packages/resize/src/resize.js
@@ -32,7 +32,7 @@
  * <-- incorrect usage-->
  * <Component use:resize/>
  * ```
- * @param {HTMLElement} node - HTMLElement to observe
+ * @param {Element} node - element to observe
  * @param {import('./public').ResizeParameter} param - svelte action parameters
  * @returns {import('./public').ResizeActionReturn}
  */


### PR DESCRIPTION
The `ResizeObserver` Web API supports `Element`, not just `HTMLElement`.

```typescript
interface ResizeObserver {
    disconnect(): void;
    observe(target: Element, options?: ResizeObserverOptions): void;
    unobserve(target: Element): void;
}
```

The current restriction of `use:resize` to just `HTMLElement` is very unfortunate, since for SVG elements Svelte doesn't even provide an equivalent to `bind:clientWidth`/`bind:clientHeight`), so `use:resize` would be even more useful here.

---

Additional sources:

### [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/ResizeObserver)

> The `ResizeObserver` constructor creates a new [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) object, which can be used to report changes to the content or border box of an [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element) or the bounding box of an [`SVGElement`](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement).

### [W3C "Resize Observer" Spec](https://www.w3.org/TR/resize-observer/#content-rect-h)

> Web content can also contain SVG elements. SVG Elements define [bounding box](https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes) instead of a content box. Content rect for [SVGGraphicsElement](https://www.w3.org/TR/SVG2/types.html#InterfaceSVGGraphicsElement)s is a rect whose:
> 
> - `width` is [bounding box](https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes) `width`
> - `height` is [bounding box](https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes) `height`
> - `top` and `left` are `0`
