### PR TITLE
Support passing optional `options` argument to `resize` action

### DIFF
--- a/.changeset/angry-frogs-retire.md
+++ b/.changeset/angry-frogs-retire.md
@@ -1,0 +1,5 @@
+---
+'@svelte-put/resize': minor
+---
+
+allow passing options to [ResizeObserver.observe](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe#options)

--- a/packages/resize/src/public.d.ts
+++ b/packages/resize/src/public.d.ts
@@ -42,6 +42,13 @@ export interface ResizeConfig {
 	 * @default 'singleton'
 	 */
 	observer?: 'singleton' | 'new' | ResizeObserver;
+
+	/**
+	 *
+	 * An options object allowing you to set options for the observation.
+	 * @default undefined
+	 */
+	options?: ResizeObserverOptions;
 }
 
 /**

--- a/packages/resize/src/public.d.ts
+++ b/packages/resize/src/public.d.ts
@@ -35,17 +35,15 @@ export interface ResizeConfig {
 	 */
 	enabled?: boolean;
 	/**
-	 *
-	 *Be default, a singleton ResizeObserver is used for all actions for
-	 *better performance. You can use this option to create a new ResizeObserver
-	 *or provide your own.
+	 * Be default, a singleton ResizeObserver is used for all actions for
+	 * better performance. You can use this option to create a new ResizeObserver
+	 * or provide your own.
 	 * @default 'singleton'
 	 */
 	observer?: 'singleton' | 'new' | ResizeObserver;
 
 	/**
-	 *
-	 * An options object allowing you to set options for the observation.
+	 * Options passed to {@link https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe#options | ResizeObserver.observe}
 	 * @default undefined
 	 */
 	options?: ResizeObserverOptions;
@@ -73,3 +71,4 @@ export type ResizeAction = Action<HTMLElement, ResizeParameter, ResizeAttributes
 
 /**  */
 export type ResizeActionReturn = ActionReturn<ResizeParameter, ResizeAttributes>;
+

--- a/packages/resize/src/resize.js
+++ b/packages/resize/src/resize.js
@@ -37,12 +37,12 @@
  * @returns {import('./public').ResizeActionReturn}
  */
 export function resize(node, param = {}) {
-	let { enabled = true, observer = 'singleton' } = param;
+	let { enabled = true, observer = 'singleton', options } = param;
 
 	let rObserver = resolveObserver(observer);
 
 	if (enabled) {
-		rObserver.observe(node);
+		rObserver.observe(node, options);
 	}
 	return {
 		update(update = {}) {
@@ -55,7 +55,7 @@ export function resize(node, param = {}) {
 			}
 
 			if (!enabled && newEnabled) {
-				rObserver.observe(node);
+				rObserver.observe(node, options);
 			} else if (enabled && !newEnabled) {
 				rObserver.unobserve(node);
 			}


### PR DESCRIPTION
The `ResizeObserver` Web API supports an optional [`options`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe#options) object on `.observe()`.

Being able to pass such an `options` object in the config would allow for picking the desired box model the observer will observe changes to, which is highly desirable in some situations.

Currently `use:resize` is restricted to [`content-box`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe#content-box), the API's default, which returns the size of the content area as defined in CSS. Other models supported by the WebAPI are:

- [`border-box`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe#border-box) Size of the box border area as defined in CSS.
- [`device-pixel-content-box`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe#device-pixel-content-box) The size of the content area as defined in CSS, in device pixels, before applying any CSS transforms on the element or its ancestors.