### PR TITLE
cloudflare-turnstile: support 'flexible' size

### DIFF
--- a/.changeset/lovely-eggs-rush.md
+++ b/.changeset/lovely-eggs-rush.md
@@ -1,0 +1,5 @@
+---
+'@svelte-put/cloudflare-turnstile': patch
+---
+
+support typing for `flexible` size

--- a/packages/cloudflare-turnstile/src/types.public.d.ts
+++ b/packages/cloudflare-turnstile/src/types.public.d.ts
@@ -31,7 +31,7 @@ export type TurnstileDataConfig = {
 	tabindex?: number;
 	'response-field'?: boolean;
 	'response-field-name'?: string;
-	size?: 'normal' | 'compact';
+	size?: 'normal' | 'flexible' | 'compact';
 	retry?: 'auto' | 'never';
 	'retry-interval'?: number;
 	'refresh-expired'?: 'auto' | 'manual' | 'never';


### PR DESCRIPTION
Cloudflare added support for a new "flexible" size: https://developers.cloudflare.com/turnstile/changelog/#2024-08-12