### PR TITLE
docs(turnstile): fix typos in Turnstile event names

### DIFF
--- a/sites/docs/src/packages/cloudflare-turnstile/docs.md.svelte
+++ b/sites/docs/src/packages/cloudflare-turnstile/docs.md.svelte
@@ -115,11 +115,11 @@ type TurnstileEventDetail<T extends Record<string, any> = Record<string, never>>
 
 type TurnstileEventAttributes = {
 	'onturnstile'?: (event: CustomEvent<TurnstileEventDetail<{ token: string }>>) => void;
-	'onturnstiletrror'?: (event: CustomEvent<TurnstileEventDetail<{ code: string }>>) => void;
-	'onturnstiletxpired'?: (event: CustomEvent<TurnstileEventDetail>) => void;
-	'onturnstileteforeinteractive'?: (event: CustomEvent<TurnstileEventDetail>) => void;
-	'onturnstiletfterinteractive'?: (event: CustomEvent<TurnstileEventDetail>) => void;
-	'onturnstiletnsupported'?: (event: CustomEvent<TurnstileEventDetail>) => void;
+	'onturnstileerror'?: (event: CustomEvent<TurnstileEventDetail<{ code: string }>>) => void;
+	'onturnstileexpired'?: (event: CustomEvent<TurnstileEventDetail>) => void;
+	'onturnstilebeforeinteractive'?: (event: CustomEvent<TurnstileEventDetail>) => void;
+	'onturnstileafterinteractive'?: (event: CustomEvent<TurnstileEventDetail>) => void;
+	'onturnstileunsupported'?: (event: CustomEvent<TurnstileEventDetail>) => void;
 	'onturnstiletimeout'?: (event: CustomEvent<TurnstileEventDetail>) => void;
 };
 ```


### PR DESCRIPTION
This fixes the event attribute names in cloudflare [turnstile page](https://svelte-put.vnphanquang.com/docs/cloudflare-turnstile#events).

The attribute names were taken from the [source code](https://github.com/vnphanquang/svelte-put/blob/d786134db3dca860de98a6939c7d81589889cf25/packages/cloudflare-turnstile/src/turnstile.js#L94-L112).